### PR TITLE
Some updates to feature/nats-server for streaming.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ include = [
     "**/*.rs",
     "Cargo.toml",
 ]
+exclude = ["examples/*"]
 keywords = [
     "nats",
     "async",
@@ -21,7 +22,7 @@ license = "MIT/Apache-2.0"
 name = "nitox"
 readme = "README.md"
 repository = "https://github.com/YellowInnovation/nitox"
-version = "0.1.8"
+version = "0.1.10"
 build = "build.rs"
 
 [package.metadata.docs.rs]
@@ -43,8 +44,8 @@ failure_derive = "0.1"
 futures = "0.1"
 log = "0.4"
 native-tls = "0.2"
-parking_lot = "0.6"
-rand = "0.5"
+parking_lot = "0.7"
+rand = "0.6"
 serde = "1.0"
 serde_derive = "1.0"
 tokio-codec = "0.1"
@@ -61,8 +62,17 @@ version = "1.0"
 
 [dev-dependencies]
 criterion = "0.2"
-env_logger = "0.5"
+env_logger = "0.6"
 tokio = "0.1"
 
 [build-dependencies]
 prost-build = { version = "0.4", optional = true }
+
+[[example]]
+name = "request_with_reply"
+
+[[example]]
+name = "publish"
+
+[[example]]
+name = "subscribe_ten_messages"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ fn connect_to_nats() -> impl Future<Item = NatsClient, Error = NatsError> {
 }
 ```
 
+## Examples
+
+In order to run the examples, you need a nats server listening to port 4222 on your localhost. If you have docker set up on your computer, you can run a nats server image in debug mode with this command :
+
+```bash
+$ docker run -p 4222:4222 nats -DV # -DV is for debug and verbose mode
+```
+
+Check out the examples and run them using cargo :
+
+```bash
+$ cargo run --example publish # Publish a message and log it in a subscriber
+$ cargo run --example request_with_reply # Publish a request and receive a response
+$ cargo run --example subscribe_ten_messages # Subscribe to 10 messages, send 15 and notice only 10 of them have been handled
+```
+
 ## License
 
 Licensed under either of these:

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -1,0 +1,65 @@
+extern crate futures;
+extern crate nitox;
+extern crate tokio;
+use futures::{future::ok, prelude::*};
+use nitox::{commands::*, NatsClient, NatsClientOptions, NatsError};
+use std::{thread::sleep, time};
+
+fn connect_to_nats() -> impl Future<Item = NatsClient, Error = NatsError> {
+    let connect_cmd = ConnectCommand::builder().build().unwrap();
+    let options = NatsClientOptions::builder()
+        .connect_command(connect_cmd)
+        .cluster_uri("127.0.0.1:4222")
+        .build()
+        .unwrap();
+
+    NatsClient::from_options(options)
+        .and_then(|client| client.connect())
+        .and_then(|client| ok(client))
+}
+
+fn handle_request(
+    message_stream: impl Stream<Item = Message, Error = NatsError> + Send + 'static,
+) -> impl Future<Item = (), Error = NatsError> {
+    tokio::spawn({
+        message_stream
+            .for_each(move |msg| {
+                // b"Hello world!""
+                println!("Received message ! {:#?}", msg.payload);
+                ok(())
+            })
+            .map_err(|_| ())
+    });
+    ok(())
+}
+
+fn main() {
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let tasks_to_perform = connect_to_nats()
+        .and_then(|client| {
+            client
+                .subscribe(SubCommand::builder().subject("topic").build().unwrap())
+                .and_then(|message_stream| handle_request(message_stream).and_then(|_| ok(client)))
+        })
+        .and_then(|client| {
+            let publish_command = PubCommand::builder()
+                .subject("topic")
+                .payload("Hello world!")
+                .build()
+                .unwrap();
+            client.publish(publish_command).and_then(|_| {
+                // Wait a little bit until the receiver logs the messae
+                sleep(time::Duration::new(1, 0));
+                ok(())
+            })
+        });
+
+    let (tx, rx) = futures::sync::oneshot::channel();
+
+    runtime.spawn(tasks_to_perform.then(|_| tx.send(()).map_err(|_| panic!("tx.send() failed!"))));
+
+    // Block until the tasks are complete and tx is sent.
+    let _ = rx.wait();
+    let _ = runtime.shutdown_now().wait();
+}

--- a/examples/request_with_reply.rs
+++ b/examples/request_with_reply.rs
@@ -1,0 +1,76 @@
+extern crate futures;
+extern crate nitox;
+extern crate tokio;
+use futures::{future::ok, prelude::*};
+use nitox::{commands::*, NatsClient, NatsClientOptions, NatsError};
+
+fn connect_to_nats() -> impl Future<Item = NatsClient, Error = NatsError> {
+    let connect_cmd = ConnectCommand::builder().build().unwrap();
+    let options = NatsClientOptions::builder()
+        .connect_command(connect_cmd)
+        .cluster_uri("127.0.0.1:4222")
+        .build()
+        .unwrap();
+
+    NatsClient::from_options(options)
+        .and_then(|client| client.connect())
+        .and_then(|client| ok(client))
+}
+
+fn handle_request(
+    request_stream: impl Stream<Item = Message, Error = NatsError> + Send + 'static,
+) -> impl Future<Item = (), Error = NatsError> {
+    tokio::spawn({
+        connect_to_nats().map_err(|_| ()).and_then(|client| {
+            request_stream
+                .for_each(move |msg| {
+                    if &msg.payload == "marco" {
+                        // b"marco"
+                        println!("{:#?}", msg.payload);
+                        if let Some(reply_subject) = msg.reply_to {
+                            let response = PubCommand::builder()
+                                .subject(reply_subject)
+                                .payload("polo")
+                                .build()
+                                .unwrap();
+                            futures::future::Either::A(client.publish(response))
+                        } else {
+                            println!("The received messages is not a request {:?}", msg);
+                            futures::future::Either::B(ok(()))
+                        }
+                    } else {
+                        println!("Received {:?} instead of marco", &msg.payload);
+                        futures::future::Either::B(ok(()))
+                    }
+                })
+                .map_err(|_| ())
+        })
+    });
+    ok(())
+}
+
+fn main() {
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let tasks_to_perform = connect_to_nats()
+        .and_then(|client| {
+            client
+                .subscribe(SubCommand::builder().subject("marcopolo").build().unwrap())
+                .and_then(|message_stream| handle_request(message_stream).and_then(|_| ok(client)))
+        })
+        .and_then(|client| {
+            client.request("marcopolo".into(), "marco".into()).and_then(|response| {
+                // b"polo"
+                println!("{:#?}", response.payload);
+                ok(())
+            })
+        });
+
+    let (tx, rx) = futures::sync::oneshot::channel();
+
+    runtime.spawn(tasks_to_perform.then(|_| tx.send(()).map_err(|_| panic!("tx.send() failed!"))));
+
+    // Block until the tasks are complete and tx is sent.
+    let _ = rx.wait();
+    let _ = runtime.shutdown_now().wait();
+}

--- a/examples/subscribe_ten_messages.rs
+++ b/examples/subscribe_ten_messages.rs
@@ -1,0 +1,78 @@
+extern crate env_logger;
+extern crate futures;
+extern crate nitox;
+extern crate tokio;
+use futures::{future::ok, prelude::*};
+use nitox::{commands::*, NatsClient, NatsClientOptions, NatsError};
+
+fn connect_to_nats() -> impl Future<Item = NatsClient, Error = NatsError> {
+    let connect_cmd = ConnectCommand::builder().build().unwrap();
+    let options = NatsClientOptions::builder()
+        .connect_command(connect_cmd)
+        .cluster_uri("127.0.0.1:4222")
+        .build()
+        .unwrap();
+
+    NatsClient::from_options(options)
+        .and_then(|client| client.connect())
+        .and_then(|client| ok(client))
+}
+
+fn handle_request(
+    message_stream: impl Stream<Item = Message, Error = NatsError> + Send + 'static,
+) -> impl Future<Item = (), Error = NatsError> {
+    message_stream.for_each(|msg| {
+        println!("Received: {:#?}", msg.payload);
+        ok(())
+    })
+}
+
+fn unsubscribe_after_10_messages(client: &NatsClient, sid: String) -> impl Future<Item = (), Error = NatsError> {
+    client.unsubscribe(UnsubCommand {
+        sid,
+        max_msgs: Some(10),
+    })
+}
+
+fn get_15_publish_tasks(client: &NatsClient) -> Vec<impl Future<Item = (), Error = NatsError>> {
+    let mut fut_vec = vec![];
+    for i in 1..=15 {
+        let pub_command = PubCommand::builder()
+            .subject("messages")
+            .payload(format!("message #{}", i))
+            .build()
+            .unwrap();
+        fut_vec.push(client.publish(pub_command).and_then(move |_| {
+            println!("Sent message #{}", i);
+            ok(())
+        }));
+    }
+    fut_vec
+}
+
+fn main() {
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let tasks_to_perform = connect_to_nats().and_then(|client| {
+        let subscribe_command = SubCommand::builder().subject("messages").build().unwrap();
+        let sc_id = subscribe_command.sid.clone();
+        // Subscribe to the Messages topic
+        client.subscribe(subscribe_command).and_then(move |message_stream| {
+            unsubscribe_after_10_messages(&client, sc_id)
+                .and_then(move |_| {
+                    // The last 5 messages won't be received
+                    let fut_vec = get_15_publish_tasks(&client);
+                    futures::future::join_all(fut_vec)
+                })
+                // Map the message stream to the handler
+                .and_then(move |_| handle_request(message_stream))
+        })
+    });
+
+    let (tx, rx) = futures::sync::oneshot::channel();
+    runtime.spawn(tasks_to_perform.then(|_| tx.send(()).map_err(|_| panic!("tx.send() failed!"))));
+
+    // Block until the tasks are complete and tx is sent.
+    let _ = rx.wait();
+    let _ = runtime.shutdown_now().wait();
+}

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -107,7 +107,8 @@ impl NatsClient {
                 } else {
                     future::ok(Either::A(connect(cluster_sa)))
                 }
-            }).and_then(|either| either)
+            })
+            .and_then(|either| either)
             .and_then(move |connection| {
                 let (sink, stream): (NatsSink, NatsStream) = connection.split();
                 let (rx, other_rx) = NatsClientMultiplexer::new(stream);
@@ -151,7 +152,8 @@ impl NatsClient {
                             }
 
                             future::ok(())
-                        }).into_future()
+                        })
+                        .into_future()
                         .map_err(|_| ()),
                 );
 
@@ -179,13 +181,24 @@ impl NatsClient {
 
     /// Send a UNSUB command to the server and de-register stream in the multiplexer
     pub fn unsubscribe(&self, cmd: UnsubCommand) -> impl Future<Item = (), Error = NatsError> + Send + Sync {
+        let mut unsub_now = true;
         if let Some(max) = cmd.max_msgs {
             if let Some(mut s) = (*self.rx.subs_tx.write()).get_mut(&cmd.sid) {
                 s.max_count = Some(max);
+                unsub_now = false;
             }
         }
 
-        self.tx.send(Op::UNSUB(cmd))
+        let sid = cmd.sid.clone();
+        let rx_arc = Arc::clone(&self.rx);
+
+        self.tx.send(Op::UNSUB(cmd)).and_then(move |_| {
+            if unsub_now {
+                rx_arc.remove_sid(&sid);
+            }
+
+            future::ok(())
+        })
     }
 
     /// Send a SUB command and register subscription stream in the multiplexer and return that `Stream` in a future
@@ -217,7 +230,6 @@ impl NatsClient {
                     if let Some(count) = delete.take() {
                         debug!(target: "nitox", "Deleted stream for sid {} at count {}", sid, count);
                         stx.remove(&sid);
-                        return Err(NatsError::SubscriptionReachedMaxMsgs(count));
                     }
                 }
 
@@ -270,6 +282,8 @@ impl NatsClient {
             .inspect(|msg| debug!(target: "nitox", "Request saw msg in multiplexed stream {:#?}", msg))
             .take(1)
             .into_future()
+            // This unwrap is safe because we take only one message from the stream which means
+            // we'll always have one and only one message there
             .map(|(surely_message, _)| surely_message.unwrap())
             .map_err(|(e, _)| e)
             .and_then(move |msg| {

--- a/src/client/multiplexer.rs
+++ b/src/client/multiplexer.rs
@@ -75,6 +75,9 @@ impl NatsClientMultiplexer {
     }
 
     pub fn remove_sid(&self, sid: &str) {
-        (*self.subs_tx.write()).remove(sid);
+        if let Some(mut tx) = (*self.subs_tx.write()).remove(sid) {
+            let _ = tx.tx.close();
+            drop(tx);
+        }
     }
 }

--- a/src/protocol/client/connect.rs
+++ b/src/protocol/client/connect.rs
@@ -60,12 +60,12 @@ impl ConnectCommandBuilder {
     fn default_ver(&self) -> Result<String, String> {
         match ::std::env::var("CARGO_PKG_VERSION") {
             Ok(v) => Ok(v),
-            Err(_) => Err("Package version not found in env".into()),
+            Err(_) => Ok("0.1.x".into()),
         }
     }
 
     fn default_lang(&self) -> Result<String, String> {
-        Ok(String::from("rust"))
+        Ok("rust".into())
     }
 }
 

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -1,7 +1,6 @@
-pub(crate) mod streaming_protocol;
-
 pub mod error;
 mod streaming_client;
+pub mod streaming_protocol;
 mod subscription;
 
 pub mod client {

--- a/src/streaming/streaming_client.rs
+++ b/src/streaming/streaming_client.rs
@@ -72,7 +72,7 @@ impl From<NatsClient> for NatsStreamingClient {
         NatsStreamingClient {
             nats: Arc::new(client),
             ack: Arc::new(RwLock::new(HashMap::new())),
-            client_id: format!("nitox.streaming.{}", Self::generate_guid()),
+            client_id: format!("nitox_streaming_{}", Self::generate_guid()),
             cluster_id: None,
             config: Arc::new(RwLock::new(NatsStreamingClientConfiguration {
                 hb_subject: Self::generate_guid(),

--- a/src/streaming/streaming_client.rs
+++ b/src/streaming/streaming_client.rs
@@ -65,7 +65,8 @@ pub struct SubscribeOptions {
 /// Control whether a subscription will automatically or manually ack received messages.
 ///
 /// By default, subscriptions will be setup to automatically ack messages which are received on
-/// the stream. Use `Manual` mode to control the acks yourself.
+/// the stream. Use `Manual` mode to control the acks yourself. Simply call `StreamingMessage.ack`
+/// to ack a message.
 #[derive(Debug, Clone)]
 pub enum SubscriptionAckMode {
     Auto,


### PR DESCRIPTION
- resolves the current (as of 2019.01.16) merge conflict in `feature/nats-server`.
- fixes a bug where streaming client IDs were being generated with `.`s in the name. Server was rejecting the client connections & consumers were being blocked. I'm a now able to consume messages off of a stream.

### todo
- [x] finish up with manual ack pattern.
Just a couple of observations for moving forward:
- [x] ~~streaming modules & types could used some docs.~~ I'll let you handle this one, @OtaK.
- [x] looks like the `streaming_protocol` module is private, so accessing the `StartPosition` variants is not possible. Maybe that is intentional, but it would def be nice to have access to the enum during development.
- [x] the `MsgProto` object (also generated by prost/protobuf)  is in the internal `streaming_protocol.rs` file and can't be accessed by stream handlers. 
- [x] ~~also, I see that the derive builder crate is used throughout (in existing code as well). I would recommend using the `typed_builder` as everything can be verified at compile time. This is super convenient, especially when dealing with futures.~~ We can open another issue for this later.