### PR TITLE
bump some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,21 +35,21 @@ failure_derive = "0.1"
 futures = "0.1"
 log = "0.4"
 native-tls = "0.2"
-parking_lot = "0.6"
-rand = "0.5"
+parking_lot = "0.9"
+rand = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
 tokio-codec = "0.1"
 tokio-executor = "0.1"
 tokio-tcp = "0.1"
 tokio-tls = "0.2"
-url = "1.7"
+url = "2.1"
 
 [dependencies.serde_json]
 features = ["preserve_order"]
 version = "1.0"
 
 [dev-dependencies]
-criterion = "0.2"
+criterion = "0.3"
 env_logger = "0.6"
 tokio = "0.1"

--- a/src/protocol/client/pub_cmd.rs
+++ b/src/protocol/client/pub_cmd.rs
@@ -26,7 +26,7 @@ impl PubCommand {
 
     /// Generates a random `reply_to` `String`
     pub fn generate_reply_to() -> String {
-        let mut rng = thread_rng();
+        let rng = thread_rng();
         rng.sample_iter(&Alphanumeric).take(16).collect()
     }
 }


### PR DESCRIPTION
This is an attempt to bump up dependencies that are old.
The aim is to reduce the number of crates compiled by end users.